### PR TITLE
Fix for issue #16

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
 	<script type="text/javascript" src="lib/angular-breadcrumb/release/angular-breadcrumb.js"></script>
 	<script type="text/javascript" src="lib/uri.js/src/URI.min.js"></script>
 	<script type="text/javascript" src="lib/angular-xeditable/dist/js/xeditable.js"></script>
-	<script type="text/javascript" src="lib/ngstorage/ngstorage.js"></script>
+	<script type="text/javascript" src="lib/ngstorage/ngStorage.js"></script>
 	<script type="text/javascript" src="lib/ngInfiniteScroll/build/ng-infinite-scroll.js"></script>
 
 	<script type="text/javascript" src="config.js"></script>


### PR DESCRIPTION
There is a typo in [index.html](https://github.com/rsdevigo/jungle/blob/master/index.html#L67) while referring `ngStorage.js`. For details about the issue please refer [Issue 16](https://github.com/rsdevigo/jungle/issues/16)